### PR TITLE
mock_helper!

### DIFF
--- a/tests/mock_helper.py
+++ b/tests/mock_helper.py
@@ -1,0 +1,73 @@
+import os
+import pytest
+import boto3
+from moto import mock_s3
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+from dfmock import DFMock
+from string import ascii_lowercase
+import random
+import tempfile
+
+class MockHelper:
+    """ creates some helpful dataset stuff.
+        - dataframe is the frame created
+        - s3_bucket is the test bucket that has been populated 
+        be sure to wrap this with moto @mock_s3 if you want to mock it
+    """ 
+
+    def __init__(self):
+        self._dataframe = self.setup_grouped_dataframe()
+        self._s3_bucket = self.setup_partitioned_parquet()
+        
+
+    @property
+    def dataframe(self):
+        return self._dataframe
+
+    @property
+    def s3_bucket(self):
+        return self._s3_bucket
+
+    def setup_grouped_dataframe(self,count=1000000):
+        df = DFMock()
+        df.count = count
+        df.columns = {  "string_col": {"option_count":3, "option_type":"string"},
+                        "int_col": {"option_count":3, "option_type":"int"},
+                        "float_col": {"option_count":3, "option_type":"float"},
+                        "bool_col": {"option_count":3, "option_type":"bool"},
+                        "datetime_col": {"option_count":3, "option_type":"datetime"},
+                        "metrics" : "int"}
+        df.generate_dataframe()
+        return df.dataframe
+    
+    def random_bucket_name(self):
+        return ''.join([random.choice(ascii_lowercase) for x in range(0,10)])
+    
+
+    def setup_partitioned_parquet(self):
+        """ pushes parquet to s3 and returns a tuple with the bucket
+            and the matching pandas df.
+        """
+        bucket_name = self.random_bucket_name()
+        t = tempfile.mkdtemp()
+        s3_client = boto3.client('s3')
+        df = self._dataframe
+        s3_client.create_bucket(Bucket=bucket_name)
+            
+        ## generate the local parquet tree
+        table = pa.Table.from_pandas(df)
+        pq.write_to_dataset(table, 
+                            root_path=str(t),
+                            partition_cols = ['string_col','int_col','float_col','bool_col','datetime_col'])
+
+        ## traverse the local parquet tree
+        paths = ''
+        for subdir, dirs, files in os.walk(str(t)):
+            for file in files:
+                full_path = os.path.join(subdir, file)
+                with open(full_path, 'rb') as data:
+                    path = full_path[1:]#[len(str(1))+1:]
+                    s3_client.put_object(Bucket=bucket_name,Key=path, Body=data)
+        

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,6 +1,6 @@
 import pytest
 import boto3
-import moto
+from moto import mock_s3
 from tests.mock_helper import MockHelper
 
 """ HOW TO USE MOCK HELPER 
@@ -28,5 +28,4 @@ from tests.mock_helper import MockHelper
 
     Since this is dynamically generated data, no 2 runs will have the same dataframes / parquet files / bucket names. 
 """ 
-
 

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,32 @@
+import pytest
+import boto3
+import moto
+from tests.mock_helper import MockHelper
+
+""" HOW TO USE MOCK HELPER 
+    mock helper builds a dataframe, builds partitioned parquet, and pushes to S3 for you. 
+    - use moto to mock it for unit tests
+    - don't use moto when you want to push to a sandbox (for integration-ish tests)
+      NOTE: this will use your real IAM / config AWS creds, so make sure all your stuff points to sandbox and not production! 
+    
+    EXAMPLE:
+
+    # mocked
+    @mock_s3
+    def test_a_thing():
+        badass_mock = MockHelper()
+        
+        ## here's a dataframe!
+        df = badass_mock.dataframe
+    
+        ## here's the s3 bucket with the partitioned parquet files in it.
+        ## Since we used moto, this is a fake S3 bucket that actually lives in memory!    
+        bucket = badass_mock.s3_bucket
+
+    you can now "download" the files from s3, check to make sure they convert back to a matching dataframe,
+    and other cool stuff. 
+
+    Since this is dynamically generated data, no 2 runs will have the same dataframes / parquet files / bucket names. 
+""" 
+
+

--- a/tests/test_s3_parc.py
+++ b/tests/test_s3_parc.py
@@ -1,5 +1,0 @@
-import pytest
-
-### test publish
-def test_publish_file_size():
-    pass


### PR DESCRIPTION
## Why? 
Setting up mocks for this project sucks. so we made a mock helper.

## What? 
`mock_helper`:
- creates a dataframe with grouped values of _nearly_ all pandas data types (no timedeltas or categories). 
- generates a partitioned parquet file tree for the data 
- uploads the data to an s3 bucket 
You can then access the dataframe and bucket name via the `dataframe` and `s3_bucket` properties (respectively) 

NOTE: this is 100% intended to be used in conjunction with (moto)[https://github.com/spulec/moto] - it does **zero** cleanup on the S3 side. if you use this on real s3, it will leave junk everywhere. 

**TODO:** ^^ fix that so it cleans up S3 at the end 