### PR TITLE
Bug patch publish meta

### DIFF
--- a/s3parq/publish_parq.py
+++ b/s3parq/publish_parq.py
@@ -78,10 +78,10 @@ def _assign_partition_meta(bucket: str, key: str, dataframe: pd.DataFrame, parti
     return all_files
 
 
-def _parse_dataframe_col_types(dataframe: pd.DataFrame, partitions: iter) -> dict:
+def _parse_dataframe_col_types(dataframe: pd.DataFrame, partitions: list) -> dict:
     """ Returns a dict with the column names as keys, the data types (in strings) as values."""
     logger.debug("Determining write metadata for publish...")
-    dataframe = pd.DataFrame(dataframe[partitions])
+    dataframe = dataframe[partitions]
     dtypes = {}
     for col, dtype in dataframe.dtypes.items():
         dtype = str(dtype)

--- a/s3parq/s3parq.py
+++ b/s3parq/s3parq.py
@@ -5,7 +5,7 @@ from s3parq.fetch_parq import fetch, get_max_partition_value, fetch_diff
 import pandas as pd
 import sys
 import logging
-from typing import Iterable
+from typing import Iterable, List
 
 
 class S3Parq:
@@ -14,15 +14,14 @@ class S3Parq:
                 bucket: str,
                 key: str,
                 dataframe: pd.DataFrame,
-                partitions: Iterable[str]) -> None:
+                partitions: Iterable[str]) -> List:
 
-        pub = publish(
+        return publish(
             dataframe=dataframe,
             bucket=bucket,
             key=key,
             partitions=partitions
         )
-        pub.publish()
 
     def fetch(self,
               bucket: str,
@@ -32,7 +31,8 @@ class S3Parq:
 
         return fetch(key=key,
                      bucket=bucket,
-                     filters=kwargs.get('partitions', dict())
+                     filters=kwargs.get('partitions', dict()),
+                     parallel=kwargs.get('parallel',True)
                      )
 
     def fetch_diff(self,

--- a/s3parq/testing_helper.py
+++ b/s3parq/testing_helper.py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+def df_equal_by_set(df1:pd.DataFrame, df2:pd.DataFrame, cols:iter)->bool:
+    set1,set2 = list(), list()
+    for col in cols:
+        set1.append(df1[col])
+        set2.append(df2[col])
+    zipped1 = set(zip(*set1)) 
+    zipped2 = set(zip(*set2))
+    
+    return (zipped1 == zipped2)

--- a/tests/test_fetch_parq.py
+++ b/tests/test_fetch_parq.py
@@ -38,7 +38,7 @@ class Test():
     def mock_publish(self, partition_types: Dict[str, str], bucket="safebucketname", key='safekeyprefixname/safedatasetname'):
         mocker = MockHelper(count=100, s3=True)
         df = mocker.dataframe
-        partitions = partition_types.keys()
+        partitions = list(partition_types.keys())
         dfmock = DFMock()
         dfmock.count = 10
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,25 +1,27 @@
 import boto3
 import moto
-import s3_parq
+import s3parq
 import pytest
 import dfmock
+from s3parq.testing_helper import df_equal_by_set
 from s3parq.publish_parq import publish
 from s3parq.fetch_parq import fetch
 import pandas as pd
 
 
+# make a sample DF for all the tests
+df = dfmock.DFMock(count=10000)
+df.columns = {"string_options": {"option_count": 4, "option_type": "string"},
+              "int_options": {"option_count": 4, "option_type": "int"},
+              "datetime_options": {"option_count": 5, "option_type": "datetime"},
+              "float_options": {"option_count": 2, "option_type": "float"},
+              "metrics": "integer"
+              }
+df.generate_dataframe()
+
+
 @moto.mock_s3
 def test_end_to_end():
-    # make it
-    df = dfmock.DFMock(count=10000)
-    df.columns = {"string_options": {"option_count": 4, "option_type": "string"},
-                  "int_options": {"option_count": 4, "option_type": "int"},
-                  "datetime_options": {"option_count": 5, "option_type": "datetime"},
-                  "float_options": {"option_count": 2, "option_type": "float"},
-                  "metrics": "integer"
-                  }
-    df.generate_dataframe()
-
     s3_client = boto3.client('s3')
 
     bucket_name = 'thistestbucket'
@@ -46,3 +48,25 @@ def test_end_to_end():
     assert dataframe.shape == df.dataframe.shape
     pd.DataFrame.eq(dataframe, df.dataframe)
     dataframe.head()
+
+@moto.mock_s3
+def test_via_public_interface():
+    s3_client = boto3.client('s3')
+    bucket_name = 'another-bucket'
+    key = 'testing/is/fun/dataset-name'
+    s3_client.create_bucket(Bucket=bucket_name)
+
+    parq = s3parq.S3Parq()
+    parq.publish(bucket=bucket_name,
+                key=key,
+                dataframe=df.dataframe,
+                partitions=['datetime_options'])
+
+    ## moto explodes when we use parallel :( need to test this with a real boto call
+    result = parq.fetch(bucket=bucket_name,
+                        key=key,
+                        parallel=False
+                        )
+    assert result.shape == df.dataframe.shape
+    assert df_equal_by_set(result, df.dataframe, df.dataframe.columns.tolist())
+


### PR DESCRIPTION
## Why? 
Fixing the oversize metadata bug meant everything exploded when we have a zero-row result. This fixes it by grabbing a single file and then truncating the frame.
