### PR TITLE
Release 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from os import path
 
 package_name = "s3parq"
-package_version = "0.0.2"
+package_version = "1.0.0"
 description = "Write and read/query s3 parquet data using Athena/Spectrum/Hive style partitioning."
 cur_directory = path.abspath(path.dirname(__file__))
 with open(path.join(cur_directory, 'README.md'), encoding='utf-8') as f:


### PR DESCRIPTION
WOOO! Release 1.0.0
This release scales meta so we can handle thousands of columns without hitting the AWS meta limit. 
Also reduces meta writes to only new parquet files. 