### PR TITLE
Dupe fetch fix

### DIFF
--- a/s3parq/fetch_parq.py
+++ b/s3parq/fetch_parq.py
@@ -359,17 +359,18 @@ def _get_filtered_data(bucket: str, paths: list, partition_metadata, parallel=Tr
     def append_to_temp(frame):
         temp_frames.append(frame)
 
-    for path in paths:
-        if parallel:
-            with get_context("spawn").Pool() as pool:
-                for path in paths:
-                    append_to_temp(
-                        pool.apply_async(_s3_parquet_to_dataframe, args=(bucket, path, partition_metadata)).get())
-                pool.close()
-                pool.join()
-        else:
+    if parallel:
+        with get_context("spawn").Pool() as pool:
+            for path in paths:
+                append_to_temp(
+                    pool.apply_async(_s3_parquet_to_dataframe, args=(bucket, path, partition_metadata)).get())
+            pool.close()
+            pool.join()
+    else:
+        for path in paths:
             append_to_temp(_s3_parquet_to_dataframe(
                 bucket, path, partition_metadata))
+                
     return pd.concat(temp_frames)
 
 

--- a/tests/mock_helper.py
+++ b/tests/mock_helper.py
@@ -117,12 +117,12 @@ class MockHelper:
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             for x in range(count):
-                t = tempfile.NamedTemporaryFile(dir=tmp_dir)
-                head, tail = os.path.split(t.name)
-                temp_file_names.append(str(tail))
-                with open(t.name, 'rb') as data:
-                    s3_client.upload_fileobj(
-                        data, Bucket=bucket_name, Key=(key+tail))
+                with tempfile.NamedTemporaryFile(dir=tmp_dir) as t:
+                    head, tail = os.path.split(t.name)
+                    temp_file_names.append(str(tail))
+                    with open(t.name, 'rb') as data:
+                        s3_client.upload_fileobj(
+                            data, Bucket=bucket_name, Key=(key+"/"+tail + ".parquet"))
 
         retrieval_ops = {
             "bucket": bucket_name,

--- a/tests/test_fetch_parq.py
+++ b/tests/test_fetch_parq.py
@@ -425,13 +425,16 @@ class Test():
             'fake-key/fil-1=5.45/fil-2=2/fil-3=str_rng/'
         ]
 
-        key = "fake-key/"
+        key = "fake-key"
         filters = filters
 
         filter_paths = fetch_parq._get_filtered_key_list(
             typed_parts=typed_parts, key=key, filters=filters)
 
-        assert list.sort(filter_paths) == list.sort(fil_paths)
+        filter_paths.sort()
+        fil_paths.sort()
+
+        assert filter_paths == fil_paths
 
     # Test that it handles filters ridding everything
     def test_filter_to_none(self):

--- a/tests/test_fetch_parq.py
+++ b/tests/test_fetch_parq.py
@@ -108,9 +108,12 @@ class Test():
         fetched_files = fetch_parq._get_all_files_list(bucket, key)
 
         test_files_keyed = list(
-            map(lambda x: key + x, test_files))
+            map(lambda x: key + "/" + x + ".parquet", test_files))
 
-        assert (test_files_keyed.sort()) == (fetched_files.sort())
+        test_files_keyed.sort()
+        fetched_files.sort()
+
+        assert (test_files_keyed == fetched_files)
 
     # Test that all files matching key get listed out even with pagination
     def test_fetch_files_list_more_than_1k(self):
@@ -124,9 +127,12 @@ class Test():
         fetched_files = fetch_parq._get_all_files_list(bucket, key)
 
         test_files_keyed = list(
-            map(lambda x: key + x, test_files))
+            map(lambda x: key + "/" + x + ".parquet", test_files))
 
-        assert (test_files_keyed.sort()) == (fetched_files.sort())
+        test_files_keyed.sort()
+        fetched_files.sort()
+
+        assert (test_files_keyed == fetched_files)
 
     # Test that all valid partitions are correctly parsed
     def test_get_partitions(self):
@@ -154,7 +160,7 @@ class Test():
             }
         })
 
-        key = "key/"
+        key = "key"
         test_parsed_part = fetch_parq._parse_partitions_and_values(parts, key)
 
         assert parsed_parts == test_parsed_part
@@ -170,7 +176,7 @@ class Test():
         ]
         parsed_parts = OrderedDict({})
 
-        key = "key/"
+        key = "key"
         test_parsed_part = fetch_parq._parse_partitions_and_values(parts, key)
 
         assert parsed_parts == test_parsed_part
@@ -380,13 +386,16 @@ class Test():
             'fake-key/fil-1=5.45/fil-2=2/fil-3=str/'
         ]
 
-        key = "fake-key/"
+        key = "fake-key"
         filters = filters
 
         filter_paths = fetch_parq._get_filtered_key_list(
             typed_parts=typed_parts, filters=filters, key=key)
 
-        assert list.sort(filter_paths) == list.sort(fil_paths)
+        filter_paths.sort()
+        fil_paths.sort()
+
+        assert filter_paths == fil_paths
 
     # Test that it filters partitions when only some are filtered
     def test_filter_some_parts(self):
@@ -472,7 +481,10 @@ class Test():
         filter_paths = fetch_parq._get_filtered_key_list(
             typed_parts=typed_parts, key=key, filters=filters)
 
-        assert list.sort(filter_paths) == list.sort(fil_paths)
+        filter_paths.sort()
+        fil_paths.sort()
+
+        assert filter_paths == fil_paths
 
     # Test getting the file list for all paths
     def test_get_all_file_lists(self):
@@ -547,7 +559,7 @@ class Test():
         print(f"Key is: {key}")
 
         bucket = "foobucket"
-        key = "fookey/"
+        key = "fookey"
         partitions = partition_types.keys()
         bucket, df, partitions, published_files = self.mock_publish(
             bucket=bucket, key=key, partition_types=partition_types)


### PR DESCRIPTION
What:
This fixes an issue where fetch runs through a for loop twice on partitions, also huge amount of bugged unit tests from completely flopping on Python's returns.
Why:
All were bugs in intended function.