### PR TITLE
Added handling for no files :no_entry_sign:

### DIFF
--- a/s3parq/__init__.py
+++ b/s3parq/__init__.py
@@ -2,4 +2,6 @@ __version__ = "1.0.1"
 from .s3parq import S3Parq
 
 from s3parq.fetch_parq import fetch
+from s3parq.fetch_parq import fetch_diff
+from s3parq.fetch_parq import get_max_partition_value
 from s3parq.publish_parq import publish

--- a/s3parq/fetch_parq.py
+++ b/s3parq/fetch_parq.py
@@ -285,12 +285,12 @@ def _get_all_files_list(bucket, key) -> list:
                             'Prefix': key}
     page_iterator = paginator.paginate(**operation_parameters)
     for page in page_iterator:
-        if "Contents" in page.keys():
-            for item in page['Contents']:
-                if item['Key'].endswith('.parquet'):
-                    objects_in_bucket.append(item['Key'])
-        else:
-            pass
+        if not "Contents" in page.keys():
+            break
+
+        for item in page['Contents']:
+            if item['Key'].endswith('.parquet'):
+                objects_in_bucket.append(item['Key'])
 
     return objects_in_bucket
 

--- a/s3parq/fetch_parq.py
+++ b/s3parq/fetch_parq.py
@@ -81,6 +81,10 @@ Phase 3:
 def get_all_partition_values(bucket: str, key: str, partition: str) -> iter:
     """retruns all values, correctly typed, for a given partition IN NO ORDER."""
     all_files = _get_all_files_list(bucket, key)
+
+    if not all_files:
+        return []
+
     partition_dtype = _get_partitions_and_types(
         first_file_key=all_files[0], bucket=bucket)[partition]
     partition_values = _parse_partitions_and_values(all_files, key=key)[
@@ -95,6 +99,14 @@ def get_diff_partition_values(bucket: str, key: str, partition: str, values_to_d
             reverse: if True, will look for the values in values_to_diff that are not in partition values (basically backwards)    
      """
     all_files = _get_all_files_list(bucket, key)
+
+    if not all_files:
+        if reverse:
+            diff = set([str(val) for val in values_to_diff])
+            return diff
+        else:
+            return []
+
     partition_dtype = _get_partitions_and_types(
         first_file_key=all_files[0], bucket=bucket)[partition]
     partition_values = _parse_partitions_and_values(all_files, key=key)[
@@ -102,6 +114,12 @@ def get_diff_partition_values(bucket: str, key: str, partition: str, values_to_d
 
     partition_set = set(partition_values)
     values_to_diff_set = set([str(val) for val in values_to_diff])
+
+    if not values_to_diff:
+        if reverse:
+            return []
+        else:
+            return partition_set
 
     if reverse:
         diff = values_to_diff_set - partition_set
@@ -117,6 +135,9 @@ def get_max_partition_value(bucket: str, key: str, partition: str) -> any:
     S3NamingHelper().validate_bucket_name(bucket_name=bucket)
 
     all_files = _get_all_files_list(bucket=bucket, key=key)
+
+    if not all_files:
+        return None
 
     partition_dtype = _get_partitions_and_types(
         first_file_key=all_files[0], bucket=bucket)[partition]
@@ -136,6 +157,10 @@ def fetch(bucket: str, key: str, filters: List[type(Filter)] = {}, parallel: boo
     S3NamingHelper().validate_bucket_name(bucket)
 
     all_files = _get_all_files_list(bucket, key)
+
+    if not all_files:
+        return pd.DataFrame()
+
     partition_metadata = _get_partitions_and_types(all_files[0], bucket)
 
     _validate_matching_filter_data_type(partition_metadata, filters)
@@ -156,18 +181,19 @@ def fetch(bucket: str, key: str, filters: List[type(Filter)] = {}, parallel: boo
             if file.startswith(prefix):
                 files_to_load.append(file)
                 continue
-    ## if there is no data matching the filters, return an empty DataFrame
-    ## with correct headers and type
+    # if there is no data matching the filters, return an empty DataFrame
+    # with correct headers and type
     if len(files_to_load) < 1:
-        sacrifical_files = [all_files[0]]   
-        sacrifical_frame = _get_filtered_data(bucket=bucket, paths=sacrifical_files ,partition_metadata =partition_metadata, parallel=parallel)
+        sacrifical_files = [all_files[0]]
+        sacrifical_frame = _get_filtered_data(
+            bucket=bucket, paths=sacrifical_files, partition_metadata=partition_metadata, parallel=parallel)
         return sacrifical_frame.head(0)
 
     return _get_filtered_data(bucket=bucket, paths=files_to_load, partition_metadata=partition_metadata,
                               parallel=parallel)
 
 
-def fetch_diff(input_bucket: str, input_key: str, comparison_bucket: str, comparison_key: str, partition: str, parallel: bool = True) -> pd.DataFrame:
+def fetch_diff(input_bucket: str, input_key: str, comparison_bucket: str, comparison_key: str, partition: str, reverse: bool = False, parallel: bool = True) -> pd.DataFrame:
     ''' Returns a dataframe of whats in the input dataset but not the comparison dataset by the specified partition
         ARGS:
             input_bucket (str): the bucket of the dataset to start from
@@ -186,7 +212,8 @@ def fetch_diff(input_bucket: str, input_key: str, comparison_bucket: str, compar
         bucket=input_bucket,
         key=input_key,
         partition=partition,
-        values_to_diff=comparison_values
+        values_to_diff=comparison_values,
+        reverse=reverse
     )
 
     filters = [{
@@ -258,9 +285,12 @@ def _get_all_files_list(bucket, key) -> list:
                             'Prefix': key}
     page_iterator = paginator.paginate(**operation_parameters)
     for page in page_iterator:
-        for item in page['Contents']:
-            if item['Key'].endswith('.parquet'):
-                objects_in_bucket.append(item['Key'])
+        if "Contents" in page.keys():
+            for item in page['Contents']:
+                if item['Key'].endswith('.parquet'):
+                    objects_in_bucket.append(item['Key'])
+        else:
+            pass
 
     return objects_in_bucket
 
@@ -370,7 +400,7 @@ def _get_filtered_data(bucket: str, paths: list, partition_metadata, parallel=Tr
         for path in paths:
             append_to_temp(_s3_parquet_to_dataframe(
                 bucket, path, partition_metadata))
-                
+
     return pd.concat(temp_frames)
 
 

--- a/s3parq/s3parq.py
+++ b/s3parq/s3parq.py
@@ -27,7 +27,7 @@ class S3Parq:
               bucket: str,
               key: str,
               **kwargs
-              ) -> None:
+              ) -> pd.DataFrame:
 
         return fetch(key=key,
                      bucket=bucket,
@@ -41,6 +41,7 @@ class S3Parq:
         comparison_bucket: str, 
         comparison_key: str, 
         partition: str, 
+        reverse: bool = False,
         parallel: bool = True
     ) -> pd.DataFrame:
         return fetch_diff(
@@ -49,6 +50,7 @@ class S3Parq:
             comparison_bucket = comparison_bucket, 
             comparison_key = comparison_key, 
             partition = partition, 
+            reverse = reverse,
             parallel = parallel
         )
 

--- a/tests/test_publish_parq.py
+++ b/tests/test_publish_parq.py
@@ -93,6 +93,15 @@ class Test:
             set(zip(dataframe.int_col, dataframe.float_col,
                     dataframe.text_col, dataframe.grouped_col)) == set()
 
+    def test_reject_empty_dataframe(self):
+        dataframe = pd.DataFrame()
+        bucket, key = self.setup_s3()
+        s3_path = f"s3://{bucket}/{key}"
+
+        with pytest.raises(ValueError):
+            parq.publish(bucket=bucket, key=key,
+                        dataframe=dataframe, partitions=[])
+
     def test_set_metadata_correctly(self):
         columns, dataframe = self.setup_df()
         bucket, key = self.setup_s3()


### PR DESCRIPTION
What:
This makes it so that s3parq's fetch functions and all functions that might hit this issue can handle when there are no files by the prefix in an expected way. This also makes publish reject empty dataframes as it does not put out a parquet file and errors down the way.
Given that the main functionality of this is to fix the diff operators, a bug of reverse not being available through the calling layer was also fixed.
This PR also handles Publish being able to work with over 1000 files in the dataset through Boto's paginator.

Why:
Handles the issues of #26 , the common edge case was missed and it was causing weird errors. It also made functionality less predictable in those edge cases.
Handles a bug of reverse not actually being able to be called in the main interface.
Handles future case of huge datasets for publish to be able to apply metadata to all of the parquets.