### PR TITLE
Hotfix for redshift/pyarrow schema weirdness

### DIFF
--- a/s3parq/__init__.py
+++ b/s3parq/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 from s3parq.fetch_parq import fetch
 from s3parq.fetch_parq import fetch_diff

--- a/s3parq/publish_parq.py
+++ b/s3parq/publish_parq.py
@@ -57,7 +57,8 @@ def check_redshift_params(redshift_params: dict):
             raise ValueError(params_type_message)
     for param in expected_params:
         if param not in redshift_params.keys():
-            raise KeyError(f"Error: Required parameter {param} not found in passed redshift_params.")
+            params_key_message = f"Error: Required parameter {param} not found in passed redshift_params."
+            raise KeyError(params_key_message)
         
 
     logger.debug('Done checking redshift params')

--- a/s3parq/publish_parq.py
+++ b/s3parq/publish_parq.py
@@ -44,17 +44,21 @@ def check_partitions(partitions: iter, dataframe: pd.DataFrame)->None:
             raise ValueError(partition_message)
     logger.debug("Done checking partitions.")
 
-
-def check_redshift_params(redshift_params: list):
+def check_redshift_params(redshift_params: dict):
+    expected_params = ["schema_name", "table_name", "iam_role", "region", "cluster_id", "host", "port", "db_name"]
     logger.debug("Checking redshift params are correctly formatted")
     number_redshift_params = 8
     if len(redshift_params) != number_redshift_params:
         params_length_message = f"Expected parameters: {number_redshift_params}. Received: {len(redshift_params)}"
         raise ValueError(params_length_message)
-    for item in redshift_params:
+    for item in redshift_params.values():
         if type(item) != str:
             params_type_message = f"Expected type: String. Received: {type(item)}"
             raise ValueError(params_type_message)
+    for param in expected_params:
+        if param not in redshift_params.keys():
+            raise KeyError(f"Error: Required parameter {param} not found in passed redshift_params.")
+        
 
     logger.debug('Done checking redshift params')
 

--- a/s3parq/publish_parq.py
+++ b/s3parq/publish_parq.py
@@ -231,7 +231,7 @@ def publish(bucket: str, key: str, partitions: List['str'], dataframe: pd.DataFr
 
     if redshift_params:
         if "index" in dataframe.columns:
-            raise ValueError("'index' is a reserved keyword in pyarrow. Please remove or rename your DataFrame's 'index' column.")
+            raise ValueError("'index' is a reserved keyword in Redshift. Please remove or rename your DataFrame's 'index' column.")
 
         logger.debug("Found redshift parameters. Checking validity of params...")
         check_redshift_params(redshift_params)

--- a/s3parq/publish_parq.py
+++ b/s3parq/publish_parq.py
@@ -51,9 +51,9 @@ def check_redshift_params(redshift_params: dict):
     if len(redshift_params) != number_redshift_params:
         params_length_message = f"Expected parameters: {number_redshift_params}. Received: {len(redshift_params)}"
         raise ValueError(params_length_message)
-    for item in redshift_params.values():
-        if type(item) != str:
-            params_type_message = f"Expected type: String. Received: {type(item)}"
+    for key, item in redshift_params.items():
+        if not item:
+            params_type_message = f"No value assigned for param {key}."
             raise ValueError(params_type_message)
     for param in expected_params:
         if param not in redshift_params.keys():

--- a/s3parq/publish_parq.py
+++ b/s3parq/publish_parq.py
@@ -135,6 +135,8 @@ def _parquet_schema(dataframe: pd.DataFrame)->pa.Schema:
             pa_type = pa.float32()
         elif dtype.startswith('float64'):
             pa_type = pa.float64()
+        elif dtype.startswith('datetime'):
+            pa_type = pa.timestamp('s')
         elif dtype.startswith('date'):
             pa_type = pa.date64()
         elif dtype.startswith('category'):
@@ -142,7 +144,7 @@ def _parquet_schema(dataframe: pd.DataFrame)->pa.Schema:
         elif dtype == 'bool':
             pa_type = pa.bool_()
         else:
-            raise ValueError(f"Error: {dtype} is not a datatype which can be mapped to Parquet.")
+            raise NotImplementedError(f"Error: {dtype} is not a datatype which can be mapped to Parquet using s3parq.")
         fields.append(pa.field(col, pa_type))
 
     return pa.schema(fields=fields)

--- a/s3parq/publish_parq.py
+++ b/s3parq/publish_parq.py
@@ -238,7 +238,7 @@ def publish(bucket: str, key: str, partitions: List['str'], dataframe: pd.DataFr
         logger.debug("Redshift parameters valid. Opening Session helper.")
         session_helper = SessionHelper(
             region = redshift_params['region'],
-            cluster_id = redshift_params['cluster'],
+            cluster_id = redshift_params['cluster_id'],
             host = redshift_params['host'],
             port = redshift_params['port'],
             db_name = redshift_params['db_name']

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from os import path
 
 package_name = "s3parq"
-package_version = "2.1.0"
+package_version = "2.1.1"
 description = "Write and read/query s3 parquet data using Athena/Spectrum/Hive style partitioning."
 cur_directory = path.abspath(path.dirname(__file__))
 with open(path.join(cur_directory, 'README.md'), encoding='utf-8') as f:

--- a/tests/test_publish_parq.py
+++ b/tests/test_publish_parq.py
@@ -45,7 +45,7 @@ class Test:
             'table_name': 'hamburger_table',
             'iam_role': 'hamburger_arn',
             'region': 'us-east-1',
-            'cluster': 'hamburger_cluster',
+            'cluster_id': 'hamburger_cluster',
             'host': 'hamburger_host',
             'port': '9999',
             'db_name': 'hamburger_db'
@@ -148,7 +148,7 @@ class Test:
         redshift_params = self.setup_redshift_params()
         msh = mock_session_helper(
             region = redshift_params['region'],
-            cluster_id = redshift_params['cluster'],
+            cluster_id = redshift_params['cluster_id'],
             host = redshift_params['host'],
             port = redshift_params['port'],
             db_name = redshift_params['db_name']
@@ -169,7 +169,7 @@ class Test:
         redshift_params = self.setup_redshift_params()
         msh = mock_session_helper(
             region = redshift_params['region'],
-            cluster_id = redshift_params['cluster'],
+            cluster_id = redshift_params['cluster_id'],
             host = redshift_params['host'],
             port = redshift_params['port'],
             db_name = redshift_params['db_name']

--- a/tests/test_schema_creator.py
+++ b/tests/test_schema_creator.py
@@ -39,5 +39,4 @@ class Test():
             mock_scope.execute.assert_called_once_with(f"CREATE EXTERNAL SCHEMA IF NOT EXISTS {schema_name} \
                 FROM DATA CATALOG \
                 database '{db_name}' \
-                iam_role '{iam_role}' \
-                CREATE EXTERNAL DATABASE IF NOT EXISTS;")
+                iam_role '{iam_role}';")

--- a/tests/test_table_creator.py
+++ b/tests/test_table_creator.py
@@ -59,7 +59,7 @@ class Test():
     #Test to check that the passed in datatype maps correctly
     def test_datatype_mapper(self):
         columns = {'grouped_col': 'object', 'text_col': 'object', 'int_col': 'int64', 'float_col': 'float64'}
-        expected = {'grouped_col': 'VARCHAR', 'text_col': 'VARCHAR', 'int_col': 'INTEGER', 'float_col': 'REAL'}
+        expected = {'grouped_col': 'VARCHAR', 'text_col': 'VARCHAR', 'int_col': 'BIGINT', 'float_col': 'FLOAT'}
         sql = ""
         for key, val in expected.items():
             sql += f'{key} {val}, '

--- a/tests/test_table_creator.py
+++ b/tests/test_table_creator.py
@@ -27,7 +27,7 @@ class Test():
         columns = {'grouped_col': 'object', 'text_col': 'object', 'int_col': 'int64', 'float_col': 'float64'}
         partitions = {'fish': 'object'}
         
-        expected_sql = f'CREATE EXTERNAL TABLE {schema_name}.{table_name} {columns} \
+        expected_sql = f'CREATE EXTERNAL TABLE IF NOT EXISTS {schema_name}.{table_name} {columns} \
             PARTITIONED BY {partitions} STORED AS PARQUET \
             LOCATION "{path}";'
         with mock_session_helper.db_session_scope() as mock_scope:
@@ -48,7 +48,7 @@ class Test():
         columns = {'grouped_col': 'object', 'text_col': 'object', 'int_col': 'int64', 'float_col': 'float64'}
         partitions = {}
         
-        expected_sql = f'CREATE EXTERNAL TABLE {schema_name}.{table_name} {columns} \
+        expected_sql = f'CREATE EXTERNAL TABLE IF NOT EXISTS {schema_name}.{table_name} {columns} \
             STORED AS PARQUET \
             LOCATION "{path}";'
         with mock_session_helper.db_session_scope() as mock_scope:


### PR DESCRIPTION
We now manually assign a pyarrow schema on table creation. The pyarrow schema is constructed from the published dataframe in the new _parquet_schema() function.