### PR TITLE
made changes to the schema mapping for pyarrow

### DIFF
--- a/s3parq/publish_parq.py
+++ b/s3parq/publish_parq.py
@@ -136,7 +136,7 @@ def _parquet_schema(dataframe: pd.DataFrame)->pa.Schema:
         elif dtype.startswith('float64'):
             pa_type = pa.float64()
         elif dtype.startswith('datetime'):
-            pa_type = pa.timestamp('s')
+            pa_type = pa.timestamp('ns')
         elif dtype.startswith('date'):
             pa_type = pa.date64()
         elif dtype.startswith('category'):


### PR DESCRIPTION
Hallie was having issues publishing with redshift set to false because of a datetime[ns] datatype and it turned out to be an issue with how we were mapping pandas datatypes to pyarrow datatypes.   