### PR TITLE
Remove off-by-one index error for large dataframes publish

### DIFF
--- a/s3parq/publish_parq.py
+++ b/s3parq/publish_parq.py
@@ -224,7 +224,7 @@ ideal size: {ideal_size} bytes
     logger.info(f"Sized out {len(range(0, num_rows, rows_per_partition))} dataframes.")
     for index, lower in enumerate(range(0, num_rows, rows_per_partition)):
         lower = lower if lower == 0 else lower + 1
-        if index + 1 == num_partitions:
+        if index == num_partitions:
             upper = num_rows
         else:
             if lower == 0:


### PR DESCRIPTION
What:
This removes an index increment that was left over from the old way of splitting large dataframes up in publish

Why:
This introduced an error on large dataframes where a small amount of duplicate rows would be introduced. When the switch to passing the slice arrays instead of chunks occurred the code in this place should have changed too; it was missed and introduced error.

NOTE:
The unit tests do _not_ catch large dataframes splitting into multiple parquet files as a use case. These need to be fixed! That will occur in a separate effort as there is a nontrivial amount of work in fixing those up.