### PR TITLE
Made fetch ignore index

### DIFF
--- a/s3parq/fetch_parq.py
+++ b/s3parq/fetch_parq.py
@@ -505,7 +505,7 @@ def _get_filtered_data(bucket: str, paths: List[str], partition_metadata: dict, 
             append_to_temp(_s3_parquet_to_dataframe(
                 bucket, path, partition_metadata))
 
-    return pd.concat(temp_frames)
+    return pd.concat(temp_frames, ignore_index=True)
 
 
 def _s3_parquet_to_dataframe(bucket: str, key: str, partition_metadata: dict) -> pd.DataFrame:


### PR DESCRIPTION
What:
Changed the fetch concat to ignore the index, so after concat it will be a freshly generated one

Why:
Index is not preserved with publish. When we fetch a multi-parquest dataset, every file's dataframe is started fresh at 0. With the fully concatenated dataframe, this has duplicate index values which will break some Pandas functionality if its not manually reset.