### PR TITLE
Fixed setup.py vs requirements dependencies listings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ If redshift_params is present but invalid, the entire `publish()` fails.
 ## Gotchas
 - Filters can only be applied to partitions; this is because we do not actually pull down any of the data until after the filtering has happened. This aligns with data best practices; the things you filter on regularly are the things you should partition on!
 
+- Dataframe index is _not_ preserved!
+
 - Metadata in AWS has a limit - we use a S3 object's Metadata attribute to store partition datatypes, hopefully you aren't trying to partition on so many columns that you hit it!
 
 - When using `get_diff_partition_values` remembering which set you want can be confusing. You can refer to these diagrams: 

--- a/dockerfile
+++ b/dockerfile
@@ -3,5 +3,6 @@ FROM python:3.7
 RUN mkdir /app
 COPY . /app
 WORKDIR /app
+RUN pip install -r requirements.txt
 RUN python3 setup.py install
 

--- a/setup.py
+++ b/setup.py
@@ -2,21 +2,12 @@ from setuptools import setup, find_packages
 from os import path
 
 package_name = "s3parq"
-package_version = "2.1.4a"
+package_version = "2.1.4b"
 description = "Write and read/query s3 parquet data using Athena/Spectrum/Hive style partitioning."
 cur_directory = path.abspath(path.dirname(__file__))
 with open(path.join(cur_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-
-def get_reqs():
-    reqs = []
-    with open("requirements.txt") as file:
-        for line in file:
-            # remove linebreak which is the last character of the string
-            currentReq = line[:-1]
-            reqs.append(currentReq)
-    return reqs
 
 setup(
     name=package_name,
@@ -35,5 +26,12 @@ setup(
         ],
     packages=find_packages(exclude=("tests",)),
     include_package_data=True,
-    install_requires=get_reqs()
-    )
+    install_requires=[
+            "pandas>=0.24.2, <1",
+            "pyarrow>=0.13.0",
+            "boto3>=1.9",
+            "s3fs>=0.2",
+            "psycopg2==2.8.3",
+            "SQLAlchemy>=1.3"
+    ]
+)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from os import path
 
 package_name = "s3parq"
-package_version = "2.1.4b"
+package_version = "2.1.4a"
 description = "Write and read/query s3 parquet data using Athena/Spectrum/Hive style partitioning."
 cur_directory = path.abspath(path.dirname(__file__))
 with open(path.join(cur_directory, 'README.md'), encoding='utf-8') as f:


### PR DESCRIPTION
What:
Right now, we've made our setup.py take its dependencies straight from our requirements.txt. This is a bad idea for a few of reasons - it adds unnecessary version-locks to the end users so they cant upgrade dependencies, it forces them to install all of our dev-dependencies, etc.
This PR also adds a couple house-cleaning pieces in as well.