### PR TITLE
Added loose Changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ If redshift_params is present but invalid, the entire `publish()` fails.
 ![venn diagram of reverse value](./assets/s3parq_get_diff_partition_values.png)
 ![table of difference values](./assets/s3parq_diff_table.png)
 
+## Changelog
+### 2.1.7
+- setup.py no longer requires all of our requirements.txt for developers, 
+but only crucial pieces with looser versioning
+
 ## Contribution
 We welcome pull requests!
 Some basic guidelines:

--- a/s3parq/fetch_parq.py
+++ b/s3parq/fetch_parq.py
@@ -159,11 +159,12 @@ def fetch(bucket: str, key: str, filters: List[type(Filter)] = {}, parallel: boo
         key (str): S3 key that leads to the desired dataset
         filters (List(Filter), Optional): filters to be applied to the Dataset Partitions
             Filters have the fields:
-                partition (str):
+
+                - partition (str):
                     The published partition to be applied to
-                comparison (str):
+                - comparison (str):
                     Comparison function - one of: [ == , != , > , < , >= , <= ]
-                values (List(any)): 
+                - values (List(any)): 
                     Values to compare to - must match partition data type
                     May not use multiple values with the '<', '>' comparisons
         parallel (bool, Optional):

--- a/s3parq/publish_parq.py
+++ b/s3parq/publish_parq.py
@@ -100,15 +100,16 @@ def validate_redshift_params(redshift_params: dict) -> dict:
         redshift_params (dict):
             Dictionary for Spectrum, should be provided in the following format
             The params should be formatted as follows:
-                schema_name (str): Name of the Spectrum schema to publish to
-                table_name (str): Name of the table to write the dataset as
-                iam_role (str): Role to take while writing data to Spectrum
-                region (str): AWS region for Spectrum
-                cluster_id (str): Spectrum cluster id
-                host (str): Redshift Spectrum host name
-                port (str): Redshift Spectrum port to use
-                db_name (str): Redshift Spectrum database name to use
-                ec2_user (str): If on ec2, the user that should be used
+
+                - schema_name (str): Name of the Spectrum schema to publish to
+                - table_name (str): Name of the table to write the dataset as
+                - iam_role (str): Role to take while writing data to Spectrum
+                - region (str): AWS region for Spectrum
+                - cluster_id (str): Spectrum cluster id
+                - host (str): Redshift Spectrum host name
+                - port (str): Redshift Spectrum port to use
+                - db_name (str): Redshift Spectrum database name to use
+                - ec2_user (str): If on ec2, the user that should be used
 
     Returns:
         The given redshift_params, with table and schema names lowercase
@@ -213,15 +214,16 @@ def _assign_partition_meta(bucket: str, key: str, dataframe: pd.DataFrame, parti
         redshift_params (dict, Optional):
             Dictionary for Spectrum, should be in the following format
             The params should be formatted as follows:
-                schema_name (str): Name of the Spectrum schema to publish to
-                table_name (str): Name of the table to write the dataset as
-                iam_role (str): Role to take while writing data to Spectrum
-                region (str): AWS region for Spectrum
-                cluster_id (str): Spectrum cluster id
-                host (str): Redshift Spectrum host name
-                port (str): Redshift Spectrum port to use
-                db_name (str): Redshift Spectrum database name to use
-                ec2_user (str): If on ec2, the user that should be used
+
+                - schema_name (str): Name of the Spectrum schema to publish to
+                - table_name (str): Name of the table to write the dataset as
+                - iam_role (str): Role to take while writing data to Spectrum
+                - region (str): AWS region for Spectrum
+                - cluster_id (str): Spectrum cluster id
+                - host (str): Redshift Spectrum host name
+                - port (str): Redshift Spectrum port to use
+                - db_name (str): Redshift Spectrum database name to use
+                - ec2_user (str): If on ec2, the user that should be used
 
     Returns:
         A str list of object keys of the objects that got metadata added
@@ -426,15 +428,16 @@ def publish(bucket: str, key: str, partitions: List[str], dataframe: pd.DataFram
             for data to be published to Spectrum. Leave out entirely to avoid
             publishing to Spectrum.
             The params should be formatted as follows:
-                schema_name (str): Name of the Spectrum schema to publish to
-                table_name (str): Name of the table to write the dataset as
-                iam_role (str): Role to take while writing data to Spectrum
-                region (str): AWS region for Spectrum
-                cluster_id (str): Spectrum cluster id
-                host (str): Redshift Spectrum host name
-                port (str): Redshift Spectrum port to use
-                db_name (str): Redshift Spectrum database name to use
-                ec2_user (str): If on ec2, the user that should be used
+
+                - schema_name (str): Name of the Spectrum schema to publish to
+                - table_name (str): Name of the table to write the dataset as
+                - iam_role (str): Role to take while writing data to Spectrum
+                - region (str): AWS region for Spectrum
+                - cluster_id (str): Spectrum cluster id
+                - host (str): Redshift Spectrum host name
+                - port (str): Redshift Spectrum port to use
+                - db_name (str): Redshift Spectrum database name to use
+                - ec2_user (str): If on ec2, the user that should be used
 
     Returns:
         A str list of all the newly published object keys


### PR DESCRIPTION
We didn't have a changelog going, so despite only a few (current) changes it seemed prudent to explain what changed between versions.
Also fixed that our lists in docstrings didn't use markdown format for bullets.