### PR TITLE
fixing Int32 and Int64 data type enforcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Use the `custom_publish` function with a `custom_redshift_columns` dictionary to
 
 ## Changelog
 
+### 2.1.13
+- Corrected bug to support Int32 and Int64 data types
+
 ### 2.1.12
 - Corrected chunking mechanism in publish to avoid having empty last chunk.
 

--- a/s3parq/__init__.py
+++ b/s3parq/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.12"
+__version__ = "2.1.13"
 
 from s3parq.fetch_parq import fetch
 from s3parq.fetch_parq import fetch_diff

--- a/s3parq/publish_parq.py
+++ b/s3parq/publish_parq.py
@@ -182,7 +182,7 @@ def _gen_parquet_to_s3(bucket: str, key: str, dataframe: pd.DataFrame,
         table = pa.Table.from_pandas(
             df=dataframe, schema=_parquet_schema(dataframe, custom_redshift_columns=custom_redshift_columns), preserve_index=False)
     except pa.lib.ArrowTypeError:
-        logger.warn(
+        logger.warning(
             "Dataframe conversion to pyarrow table failed, checking object columns for mixed types")
         dataframe_dtypes = dataframe.dtypes.to_dict()
         object_columns = [
@@ -190,7 +190,7 @@ def _gen_parquet_to_s3(bucket: str, key: str, dataframe: pd.DataFrame,
             col for col, col_type in dataframe_dtypes.items() if col_type == "object" and "[Decimal(" not in str(dataframe[col].values)[:9]]
         for object_col in object_columns:
             if not dataframe[object_col].apply(isinstance, args=[str]).all():
-                logger.warn(
+                logger.warning(
                     f"Dataframe column : {object_col} : in this chunk is type object but contains non-strings, converting to all-string column")
                 dataframe[object_col] = dataframe[object_col].astype(str)
 
@@ -328,10 +328,10 @@ def _parquet_schema(dataframe: pd.DataFrame, custom_redshift_columns: dict = Non
         elif dtype.startswith('int8'):
             pa_type = pa.int8()
         elif dtype.startswith('Int32'):
-            dataframe[col] = dataframe.astype({col: 'object'})
+            dataframe[col] = dataframe[col].astype({col: 'object'})
             pa_type = pa.int32()
         elif dtype.startswith('Int64'):
-            dataframe[col] = dataframe.astype({col: 'object'})
+            dataframe[col] = dataframe[col].astype({col: 'object'})
             pa_type = pa.int64()
         elif dtype.startswith('float32'):
             pa_type = pa.float32()

--- a/s3parq/publish_parq.py
+++ b/s3parq/publish_parq.py
@@ -328,10 +328,10 @@ def _parquet_schema(dataframe: pd.DataFrame, custom_redshift_columns: dict = Non
         elif dtype.startswith('int8'):
             pa_type = pa.int8()
         elif dtype.startswith('Int32'):
-            dataframe[col] = dataframe[col].astype({col: 'object'})
+            dataframe = dataframe.astype({col: 'object'})
             pa_type = pa.int32()
         elif dtype.startswith('Int64'):
-            dataframe[col] = dataframe[col].astype({col: 'object'})
+            dataframe = dataframe.astype({col: 'object'})
             pa_type = pa.int64()
         elif dtype.startswith('float32'):
             pa_type = pa.float32()

--- a/s3parq/testing_helper.py
+++ b/s3parq/testing_helper.py
@@ -5,6 +5,7 @@ import logging
 import moto
 import os
 import pandas as pd
+import numpy as np
 from pandas.util.testing import assert_frame_equal
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -291,5 +292,22 @@ def setup_custom_redshift_columns_and_dataframe():
                                "colD": "DECIMAL(5,4)",
                                "colE": "VARCHAR",
                                "colF": "BOOLEAN"}
+
+    return (dataframe, custom_redshift_columns)
+
+
+def setup_custom_redshift_columns_and_dataframe_with_null():
+    """ Create a custom_redshift_columns dictionary that contains redshift column definitions and corresponding mock dataframe """
+    sample_data = {'colA': ["A", "B", "C"], 'colB': [4, np.NaN, 6], 'colC': [4.12, 5.22, 6.57], 'colD': [
+        4.1289, 5.22, 6.577], 'colE': ["test1", "test2", "test3"], 'colF': [True, False, True], 'colG': [4, np.NaN, 6], }
+    dataframe = pd.DataFrame(data=sample_data)
+
+    custom_redshift_columns = {"colA": "VARCHAR(1000)",
+                               "colB": "BIGINT",
+                               "colC": "REAL",
+                               "colD": "DECIMAL(5,4)",
+                               "colE": "VARCHAR",
+                               "colF": "BOOLEAN",
+                               "colG": "INT"}
 
     return (dataframe, custom_redshift_columns)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from os import path
 
 package_name = "s3parq"
-package_version = "2.1.12"
+package_version = "2.1.13"
 description = "Write and read/query s3 parquet data using Athena/Spectrum/Hive style partitioning."
 cur_directory = path.abspath(path.dirname(__file__))
 with open(path.join(cur_directory, 'README.md'), encoding='utf-8') as f:


### PR DESCRIPTION
the function _parquet_schema was overwriting the dataframe instead of coeercing a column to a type. this fixes it