### PR TITLE
Pass back potentially modified dataframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Use the `custom_publish` function with a `custom_redshift_columns` dictionary to
 
 ## Changelog
 
+### 2.1.14
+- Corrected parquet_schema computation to support Int32 and Int64 data types
+
 ### 2.1.13
 - Corrected bug to support Int32 and Int64 data types
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas==0.24.2
-pyarrow==2.0.0
+pyarrow==0.13.0
 boto3==1.9.177
 s3fs==0.2.1
 dfmock==0.0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas==0.24.2
-pyarrow==0.13.0
+pyarrow==2.0.0
 boto3==1.9.177
 s3fs==0.2.1
 dfmock==0.0.14

--- a/s3parq/__init__.py
+++ b/s3parq/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.13"
+__version__ = "2.1.14"
 
 from s3parq.fetch_parq import fetch
 from s3parq.fetch_parq import fetch_diff

--- a/s3parq/publish_parq.py
+++ b/s3parq/publish_parq.py
@@ -333,10 +333,10 @@ def _parquet_schema(dataframe: pd.DataFrame, custom_redshift_columns: dict = Non
         elif dtype.startswith('int8'):
             pa_type = pa.int8()
         elif dtype.startswith('Int32'):
-            dataframe[col] = dataframe[col].astype({col: 'object'})
+            dataframe = dataframe.astype({col: 'object'})
             pa_type = pa.int32()
         elif dtype.startswith('Int64'):
-            dataframe[col] = dataframe[col].astype({col: 'object'})
+            dataframe = dataframe.astype({col: 'object'})
             pa_type = pa.int64()
         elif dtype.startswith('float32'):
             pa_type = pa.float32()

--- a/s3parq/publish_parq.py
+++ b/s3parq/publish_parq.py
@@ -328,10 +328,10 @@ def _parquet_schema(dataframe: pd.DataFrame, custom_redshift_columns: dict = Non
         elif dtype.startswith('int8'):
             pa_type = pa.int8()
         elif dtype.startswith('Int32'):
-            dataframe = dataframe.astype({col: 'object'})
+            dataframe[col] = dataframe[col].astype({col: 'object'})
             pa_type = pa.int32()
         elif dtype.startswith('Int64'):
-            dataframe = dataframe.astype({col: 'object'})
+            dataframe[col] = dataframe[col].astype({col: 'object'})
             pa_type = pa.int64()
         elif dtype.startswith('float32'):
             pa_type = pa.float32()

--- a/s3parq/testing_helper.py
+++ b/s3parq/testing_helper.py
@@ -298,16 +298,15 @@ def setup_custom_redshift_columns_and_dataframe():
 
 def setup_custom_redshift_columns_and_dataframe_with_null():
     """ Create a custom_redshift_columns dictionary that contains redshift column definitions and corresponding mock dataframe """
-    sample_data = {'colA': ["A", "B", "C"], 'colB': [4, np.NaN, 6], 'colC': [4.12, 5.22, 6.57], 'colD': [
-        4.1289, 5.22, 6.577], 'colE': ["test1", "test2", "test3"], 'colF': [True, False, True], 'colG': [4, np.NaN, 6], }
+    sample_data = {'colA': [1, 2, np.NaN], 'colB': ['DDD', None, 'FFF'],
+                   'colC': [pd.Timestamp('20131213 11:59:59.999999999'), None, pd.Timestamp('20131213 11:59:59.999999999')], 'colE': [7.5, 3.4, np.NaN]}
+
     dataframe = pd.DataFrame(data=sample_data)
 
-    custom_redshift_columns = {"colA": "VARCHAR(1000)",
-                               "colB": "BIGINT",
-                               "colC": "REAL",
-                               "colD": "DECIMAL(5,4)",
-                               "colE": "VARCHAR",
-                               "colF": "BOOLEAN",
-                               "colG": "INT"}
+    custom_redshift_columns = {"colA": "INTEGER",
+                               "colB": "VARCHAR",
+                               "colC": "TIMESTAMP",
+                               "colE": "DECIMAL(7,2)"
+                               }
 
     return (dataframe, custom_redshift_columns)


### PR DESCRIPTION
When computing the schema of a dataframe to be published, the _parquet_schema sometimes attempt to modify the datatype of the dataframe but fails to return said dataframe.
This PR corrects this and pass back the potentially modified dataframe.
